### PR TITLE
private instance setters

### DIFF
--- a/src/main/kotlin/com/github/linkymc/Linky.kt
+++ b/src/main/kotlin/com/github/linkymc/Linky.kt
@@ -13,7 +13,9 @@ import java.io.File
 class Linky : FancyPlugin() {
     companion object {
         lateinit var instance: Linky
+          private set
         lateinit var channel: Channel
+          private set
     }
 
     override fun onEnable() {


### PR DESCRIPTION
prevent illegal modification of linky instances